### PR TITLE
Add categorized layout for standard tasks

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,20 +11,26 @@
     <h1>To-Do Groups App</h1>
 
     <section id="standard-section">
-      <h2>Standard Tasks</h2>
-      <div class="form-row">
-        <label for="new-task-text">New Task:</label>
-        <input type="text" id="new-task-text" placeholder="Add a standard task" />
-        <button id="add-task-btn">Add Task</button>
+      <div class="section-title">
+        <h2>Standard Tasks</h2>
+        <p class="section-subtitle">Organize your non-periodic to-dos by category for a clearer overview.</p>
       </div>
-      <ul id="standard-list"></ul>
+      <div class="form-row stack-on-small">
+        <label for="new-category-name">New Category:</label>
+        <input type="text" id="new-category-name" placeholder="e.g., Home, Work, Errands" />
+        <button id="add-category-btn">Add Category</button>
+      </div>
+      <div id="category-grid" class="category-grid"></div>
     </section>
 
     <section id="group-section">
-      <h2>Groups</h2>
+      <div class="section-title">
+        <h2>Groups</h2>
+        <p class="section-subtitle">Define recurring task groups with their own cadence.</p>
+      </div>
       <div class="form-row">
         <label for="group-name">Name:</label>
-        <input type="text" id="group-name" />
+        <input type="text" id="group-name" placeholder="e.g., Morning Routine" />
       </div>
       <div class="form-row">
         <label for="group-start">Start time:</label>
@@ -41,7 +47,10 @@
     </section>
 
     <section id="clear-data-section">
-      <h2>Data Management</h2>
+      <div class="section-title">
+        <h2>Data Management</h2>
+        <p class="section-subtitle">Need a fresh start? Clear all stored tasks and schedules.</p>
+      </div>
       <button id="clear-data-btn">Clear All Data</button>
     </section>
   </div>

--- a/script.js
+++ b/script.js
@@ -1,6 +1,6 @@
-const standardList = document.getElementById('standard-list');
-const addTaskBtn = document.getElementById('add-task-btn');
-const newTaskText = document.getElementById('new-task-text');
+const categoryGrid = document.getElementById('category-grid');
+const addCategoryBtn = document.getElementById('add-category-btn');
+const newCategoryNameInput = document.getElementById('new-category-name');
 
 const groupNameInput = document.getElementById('group-name');
 const groupStartInput = document.getElementById('group-start');
@@ -35,6 +35,36 @@ function patchTasks(tasks) {
   });
 }
 
+function ensureStandardCategories() {
+  if (!Array.isArray(data.standard)) {
+    data.standard = [];
+    return;
+  }
+
+  const isLegacyStructure = data.standard.some(item => item && !('tasks' in item) && 'text' in item);
+  if (isLegacyStructure) {
+    const legacyTasks = data.standard.filter(item => item && 'text' in item);
+    data.standard = [{
+      id: generateId(),
+      name: 'General',
+      tasks: legacyTasks
+    }];
+  }
+
+  data.standard.forEach(category => {
+    if (!category.id) {
+      category.id = generateId();
+    }
+    if (!category.name) {
+      category.name = 'Category';
+    }
+    if (!Array.isArray(category.tasks)) {
+      category.tasks = [];
+    }
+    patchTasks(category.tasks);
+  });
+}
+
 function saveData() {
   localStorage.setItem('todo-data', JSON.stringify(data));
 }
@@ -43,19 +73,25 @@ function loadData() {
   const saved = localStorage.getItem('todo-data');
   if (saved) {
     data = JSON.parse(saved);
-    data.groups.forEach(g => {
-      if (g.duration && g.duration.value !== undefined) {
-        if (g.duration.unit === 'd') {
-          g.duration = { days: g.duration.value, hours: 0, minutes: 0 };
-        } else if (g.duration.unit === 'h') {
-          g.duration = { days: 0, hours: g.duration.value, minutes: 0 };
-        }
-      }
-    });
-    // Patch for tasks without id/subtasks for backwards compatibility
-    patchTasks(data.standard);
-    data.groups.forEach(g => patchTasks(g.tasks));
   }
+  ensureStandardCategories();
+  if (!Array.isArray(data.groups)) {
+    data.groups = [];
+  }
+  data.groups.forEach(g => {
+    if (g.duration && g.duration.value !== undefined) {
+      if (g.duration.unit === 'd') {
+        g.duration = { days: g.duration.value, hours: 0, minutes: 0 };
+      } else if (g.duration.unit === 'h') {
+        g.duration = { days: 0, hours: g.duration.value, minutes: 0 };
+      }
+    }
+    if (!Array.isArray(g.tasks)) {
+      g.tasks = [];
+    }
+    patchTasks(g.tasks);
+  });
+  saveData();
 }
 
 function collectDuration() {
@@ -105,10 +141,12 @@ function findTaskWithContext(taskId, tasks, parent = null) {
 }
 
 function findTaskById(taskId) {
-  let result = findTaskWithContext(taskId, data.standard);
-  if (result) return result;
+  for (const category of data.standard) {
+    const result = findTaskWithContext(taskId, category.tasks);
+    if (result) return result;
+  }
   for (const group of data.groups) {
-    result = findTaskWithContext(taskId, group.tasks);
+    const result = findTaskWithContext(taskId, group.tasks);
     if (result) return result;
   }
   return null;
@@ -238,6 +276,7 @@ function renderTaskTree(tasks, container, onTaskChange, onTaskDelete) {
   tasks.forEach(task => {
     const li = document.createElement('li');
     li.dataset.taskId = task.id;
+    li.classList.add('task-item');
     li.setAttribute('draggable', true);
 
     li.addEventListener('dragstart', handleDragStart);
@@ -288,7 +327,9 @@ function renderTaskTree(tasks, container, onTaskChange, onTaskDelete) {
 
     if (onTaskDelete) {
       const delBtn = document.createElement('button');
-      delBtn.textContent = 'x';
+      delBtn.textContent = '✕';
+      delBtn.classList.add('icon-button', 'destructive-button');
+      delBtn.setAttribute('aria-label', 'Delete task');
       delBtn.addEventListener('click', () => onTaskDelete(task.id));
       li.appendChild(delBtn);
     }
@@ -297,7 +338,7 @@ function renderTaskTree(tasks, container, onTaskChange, onTaskDelete) {
 
     if (task.isExpanded && task.subtasks && task.subtasks.length > 0) {
       const sublist = document.createElement('ul');
-      sublist.style.paddingLeft = '25px';
+      sublist.className = 'nested-task-list';
       li.appendChild(sublist);
       renderTaskTree(task.subtasks, sublist, onTaskChange, null);
     }
@@ -305,20 +346,102 @@ function renderTaskTree(tasks, container, onTaskChange, onTaskDelete) {
 }
 
 function renderStandard() {
-  standardList.innerHTML = '';
-  const onTaskChange = () => {
-    saveData();
-    renderAll();
-  };
-  const onTaskDelete = (taskId) => {
-    const context = findTaskById(taskId);
-    if (context) {
-      context.list.splice(context.index, 1);
+  categoryGrid.innerHTML = '';
+
+  if (data.standard.length === 0) {
+    const emptyState = document.createElement('div');
+    emptyState.className = 'empty-state';
+    emptyState.textContent = 'Create a category to start adding tasks.';
+    categoryGrid.appendChild(emptyState);
+    return;
+  }
+
+  data.standard.forEach((category, cidx) => {
+    const column = document.createElement('div');
+    column.className = 'category-column';
+    column.dataset.categoryId = category.id;
+
+    const header = document.createElement('div');
+    header.className = 'category-header';
+
+    const title = document.createElement('h3');
+    title.textContent = category.name;
+
+    const deleteBtn = document.createElement('button');
+    deleteBtn.className = 'category-delete-btn';
+    deleteBtn.classList.add('secondary-button', 'destructive-button');
+    deleteBtn.textContent = 'Remove';
+    deleteBtn.addEventListener('click', () => {
+      if (confirm(`Delete the category "${category.name}" and all of its tasks?`)) {
+        data.standard.splice(cidx, 1);
+        saveData();
+        renderAll();
+      }
+    });
+
+    header.appendChild(title);
+    header.appendChild(deleteBtn);
+    column.appendChild(header);
+
+    const body = document.createElement('div');
+    body.className = 'category-body';
+
+    const list = document.createElement('ul');
+    list.className = 'category-task-list';
+
+    const onTaskChange = () => {
       saveData();
       renderAll();
-    }
-  };
-  renderTaskTree(data.standard, standardList, onTaskChange, onTaskDelete);
+    };
+
+    const onTaskDelete = (taskId) => {
+      const context = findTaskById(taskId);
+      if (context) {
+        context.list.splice(context.index, 1);
+        saveData();
+        renderAll();
+      }
+    };
+
+    renderTaskTree(category.tasks, list, onTaskChange, onTaskDelete);
+
+    body.appendChild(list);
+
+    const addRow = document.createElement('div');
+    addRow.className = 'category-add-row stack-on-small';
+
+    const addInput = document.createElement('input');
+    addInput.type = 'text';
+    addInput.placeholder = `Add a task in ${category.name}`;
+
+    const addBtn = document.createElement('button');
+    addBtn.textContent = 'Add Task';
+    addBtn.classList.add('secondary-button');
+
+    const addTaskToCategory = () => {
+      const text = addInput.value.trim();
+      if (!text) return;
+      category.tasks.push({ id: generateId(), text, done: false, subtasks: [] });
+      addInput.value = '';
+      saveData();
+      renderAll();
+    };
+
+    addBtn.addEventListener('click', addTaskToCategory);
+    addInput.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        addTaskToCategory();
+      }
+    });
+
+    addRow.appendChild(addInput);
+    addRow.appendChild(addBtn);
+    body.appendChild(addRow);
+
+    column.appendChild(body);
+    categoryGrid.appendChild(column);
+  });
 }
 
 function allTasksDone(tasks) {
@@ -345,15 +468,15 @@ function renderGroups() {
     title.textContent = group.name;
 
     const headerRight = document.createElement('div');
-    headerRight.style.display = 'flex';
-    headerRight.style.alignItems = 'center';
+    headerRight.className = 'group-header-actions';
 
     const period = document.createElement('span');
+    period.className = 'group-period';
     period.textContent = formatDuration(group.duration);
-    period.style.marginRight = '10px';
 
     const deleteBtn = document.createElement('button');
     deleteBtn.textContent = 'Delete Group';
+    deleteBtn.classList.add('secondary-button', 'destructive-button');
     deleteBtn.addEventListener('click', () => {
       if (confirm(`Are you sure you want to delete the group "${group.name}"?`)) {
         data.groups.splice(gidx, 1);
@@ -385,34 +508,57 @@ function renderGroups() {
     };
     renderTaskTree(group.tasks, list, onTaskChange, onTaskDelete);
 
+    const addWrapper = document.createElement('div');
+    addWrapper.className = 'category-add-row stack-on-small';
+
     const addInput = document.createElement('input');
     addInput.type = 'text';
     addInput.placeholder = 'New task';
     const addBtn = document.createElement('button');
-    addBtn.textContent = 'Add';
-    addBtn.addEventListener('click', () => {
+    addBtn.textContent = 'Add Task';
+    addBtn.classList.add('secondary-button');
+    const addTaskToGroup = () => {
       if (addInput.value.trim()) {
         group.tasks.push({ id: generateId(), text: addInput.value.trim(), done: false, subtasks: [] });
         addInput.value = '';
         saveData();
         renderAll();
       }
+    };
+    addBtn.addEventListener('click', addTaskToGroup);
+    addInput.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        addTaskToGroup();
+      }
     });
+    addWrapper.appendChild(addInput);
+    addWrapper.appendChild(addBtn);
     box.appendChild(list);
-    box.appendChild(addInput);
-    box.appendChild(addBtn);
+    box.appendChild(addWrapper);
 
     updateGroupState(group, box);
     groupsDiv.appendChild(box);
   });
 }
 
-addTaskBtn.addEventListener('click', () => {
-  if (newTaskText.value.trim()) {
-    data.standard.push({ id: generateId(), text: newTaskText.value.trim(), done: false, subtasks: [] });
-    newTaskText.value = '';
-    saveData();
-    renderAll();
+const addCategory = () => {
+  const name = newCategoryNameInput.value.trim();
+  if (!name) {
+    newCategoryNameInput.focus();
+    return;
+  }
+  data.standard.push({ id: generateId(), name, tasks: [] });
+  newCategoryNameInput.value = '';
+  saveData();
+  renderAll();
+};
+
+addCategoryBtn.addEventListener('click', addCategory);
+newCategoryNameInput.addEventListener('keydown', (event) => {
+  if (event.key === 'Enter') {
+    event.preventDefault();
+    addCategory();
   }
 });
 

--- a/style.css
+++ b/style.css
@@ -1,155 +1,425 @@
-/* Basic Reset & Body Styles */
+/* Global Layout & Typography */
 body {
-  font-family: Arial, sans-serif;
-  margin: 20px;
-  background-color: #f4f7f6; /* Light background for the page */
-  color: #333;
+  font-family: 'Segoe UI', Tahoma, sans-serif;
+  margin: 0;
+  padding: 40px 24px;
+  background: #eef1f6;
+  color: #1f2937;
+  line-height: 1.5;
 }
 
-/* Main App Container */
 #app-container {
-  max-width: 900px;
-  margin: 20px auto;
-  padding: 30px;
-  background-color: #ffffff; /* White background for the app content */
-  border-radius: 12px;
-  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 40px 48px;
+  background-color: #ffffff;
+  border-radius: 24px;
+  box-shadow: 0 28px 46px -30px rgba(15, 23, 42, 0.45);
 }
 
-/* Headings */
 h1 {
   text-align: center;
-  color: #2c3e50; /* Darker blue for main heading */
-  margin-bottom: 30px;
-  font-size: 2.5em;
+  font-size: 2.4rem;
+  margin: 0 0 16px;
+  color: #0f172a;
+  letter-spacing: -0.02em;
 }
 
-h2 {
-  color: #34495e; /* Slightly lighter blue for section headings */
-  margin-top: 25px;
-  margin-bottom: 15px;
-  border-bottom: 2px solid #ecf0f1; /* Subtle separator */
-  padding-bottom: 8px;
+p {
+  margin: 0;
 }
 
-/* Sections */
 section {
-  margin-bottom: 30px;
-  padding: 20px;
-  background-color: #fdfdfd;
-  border-radius: 8px;
-  border: 1px solid #e0e0e0;
+  background: #f9fbff;
+  border: 1px solid #e5e9f2;
+  border-radius: 18px;
+  padding: 28px 32px;
+  margin-bottom: 32px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
 }
 
-/* Form Rows */
+.section-title {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 18px;
+}
+
+.section-title h2 {
+  margin: 0;
+  font-size: 1.6rem;
+  color: #1e293b;
+}
+
+.section-subtitle {
+  color: #5f6c7b;
+  font-size: 0.95rem;
+}
+
+/* Form Layout */
 .form-row {
   display: flex;
   align-items: center;
-  margin-bottom: 15px;
-  gap: 10px; /* Space between form elements */
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-bottom: 18px;
 }
 
 .form-row label {
-  display: inline-block;
-  width: 90px;
+  flex: 0 0 160px;
+  font-weight: 600;
+  color: #334155;
 }
 
 .form-row input {
-  flex-grow: 1; /* Allow inputs to take available space */
-  padding: 10px 12px;
-  border: 1px solid #ccc;
-  border-radius: 5px;
-  font-size: 1em;
-  box-sizing: border-box; /* Include padding and border in the element's total width and height */
+  flex: 1 1 220px;
+  padding: 10px 14px;
+  border: 1px solid #cbd5e1;
+  border-radius: 10px;
+  font-size: 1rem;
+  background: #ffffff;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.form-row input:focus {
+  border-color: #2563eb;
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+}
+
+.stack-on-small {
+  flex-wrap: wrap;
+}
+
+.stack-on-small input {
+  flex: 1 1 180px;
 }
 
 /* Buttons */
 button {
-  padding: 10px 20px;
-  border: none;
-  border-radius: 5px;
-  background-color: #3498db; /* Blue button */
-  color: white;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 10px 18px;
+  border-radius: 10px;
+  border: 1px solid transparent;
+  background: linear-gradient(135deg, #2563eb, #3b82f6);
+  color: #ffffff;
+  font-size: 1rem;
+  font-weight: 600;
   cursor: pointer;
-  font-size: 1em;
-  transition: background-color 0.2s ease, transform 0.1s ease;
-  white-space: nowrap; /* Prevent button text from wrapping */
+  transition: transform 0.15s ease, box-shadow 0.15s ease, filter 0.15s ease;
 }
 
 button:hover {
-  background-color: #2980b9; /* Darker blue on hover */
-  transform: translateY(-1px); /* Slight lift effect */
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px rgba(37, 99, 235, 0.25);
 }
 
 button:active {
   transform: translateY(0);
 }
 
-/* Group Box Styling */
-.group-box {
-  border: 1px solid #888;
-  margin-top: 10px;
-  padding: 5px;
-  background-color: lightyellow;
+button:disabled {
+  cursor: not-allowed;
+  filter: grayscale(0.2);
 }
 
-.group-box.done {
-  background-color: lightgreen;
-  border-color: #27ae60; /* Green border for done groups */
+.secondary-button {
+  background: #eef2ff;
+  color: #1d4ed8;
+  border-color: #dbe4ff;
+  box-shadow: none;
 }
 
-.group-header {
+.secondary-button:hover {
+  background: #dbe4ff;
+  box-shadow: none;
+}
+
+.destructive-button {
+  background: #fee2e2;
+  color: #b42318;
+  border-color: #fecaca;
+  box-shadow: none;
+}
+
+.destructive-button:hover {
+  background: #fecaca;
+  color: #7f1d1d;
+  box-shadow: none;
+}
+
+.icon-button {
+  padding: 4px 8px;
+  font-size: 0.85rem;
+  line-height: 1;
+  border-radius: 8px;
+}
+
+/* Category Columns */
+.category-grid {
   display: flex;
-  align-items: center; /* Align items vertically */
+  flex-wrap: wrap;
+  gap: 20px;
+}
+
+.category-column {
+  flex: 1 1 260px;
+  min-width: 240px;
+  background: #ffffff;
+  border: 1px solid #dde3f0;
+  border-radius: 16px;
+  box-shadow: 0 16px 32px -24px rgba(15, 23, 42, 0.35);
+  display: flex;
+  flex-direction: column;
+}
+
+.category-header {
+  display: flex;
+  align-items: center;
   justify-content: space-between;
-  border-bottom: 1px solid #888;
-  margin-bottom: 5px;
-  padding-bottom: 3px;
+  padding: 16px 18px;
+  border-bottom: 1px solid #e6ebf5;
+  background: linear-gradient(135deg, #f8fafc, #eef2ff);
+  border-top-left-radius: 16px;
+  border-top-right-radius: 16px;
+}
+
+.category-header h3 {
+  margin: 0;
+  font-size: 1.1rem;
+  color: #1f2937;
+}
+
+.category-delete-btn {
+  padding: 8px 12px;
+  font-size: 0.9rem;
+}
+
+.category-body {
+  padding: 16px 18px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  flex: 1;
+}
+
+.category-task-list {
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.nested-task-list {
+  width: 100%;
+  padding-left: 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.category-add-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.category-add-row input {
+  flex: 1 1 180px;
+}
+
+.category-add-row .secondary-button {
+  padding: 8px 14px;
+}
+
+.empty-state {
+  flex: 1 1 100%;
+  padding: 48px 32px;
+  border-radius: 18px;
+  border: 2px dashed #cbd5e1;
+  text-align: center;
+  color: #64748b;
+  background: rgba(226, 232, 240, 0.35);
+  font-weight: 500;
+}
+
+/* Task Tree Styling */
+ul {
+  list-style: none;
+  margin: 0;
+  padding-left: 0;
+}
+
+.task-item {
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 8px 10px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.task-item:hover {
+  border-color: #cbd5ff;
+  box-shadow: 0 10px 22px -20px rgba(37, 99, 235, 0.55);
 }
 
 li input[type="checkbox"] {
-  margin-right: 8px;
+  transform: scale(1.05);
 }
 
 .task-text {
+  flex: 1 1 180px;
   cursor: pointer;
 }
 
 .toggle {
   cursor: pointer;
-  margin-right: 4px;
-  display: inline-block;
-  width: 1em;
-  text-align: center;
-  user-select: none; /* Prevents text selection on click */
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.2em;
+  color: #475569;
 }
 
 .toggle-placeholder {
-  display: inline-block;
-  width: 1em;
-  margin-right: 4px;
-}
-
-ul {
-  list-style: none;
-  padding-left: 0;
-}
-
-li {
-  margin-bottom: 5px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.2em;
+  color: transparent;
 }
 
 li.dragging {
-  opacity: 0.4;
+  opacity: 0.45;
+  box-shadow: none;
 }
 
 li.drag-over {
-  border-top: 2px solid dodgerblue;
+  border-top: 2px solid #2563eb;
 }
 
 .edit-task-input {
-  font-size: inherit;
+  font-size: 1rem;
   font-family: inherit;
-  border: 1px solid #999;
-  padding: 1px 2px;
+  border: 1px solid #94a3b8;
+  padding: 6px 8px;
+  border-radius: 8px;
+  flex: 1 1 180px;
+}
+
+/* Groups */
+#groups {
+  display: grid;
+  gap: 20px;
+}
+
+.group-box {
+  border: 1px solid #dde3f0;
+  border-radius: 16px;
+  padding: 22px;
+  background: #ffffff;
+  box-shadow: 0 16px 32px -24px rgba(15, 23, 42, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.group-box.done {
+  background-color: #f0fdf4;
+  border-color: #86efac;
+}
+
+.group-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid #e6ebf5;
+}
+
+.group-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.group-period {
+  font-weight: 600;
+  color: #334155;
+  background: #e0f2fe;
+  padding: 4px 12px;
+  border-radius: 999px;
+  font-size: 0.85rem;
+}
+
+/* Clear data button */
+#clear-data-btn {
+  background: linear-gradient(135deg, #f97316, #fb923c);
+  border-color: #fb923c;
+}
+
+#clear-data-btn:hover {
+  box-shadow: 0 10px 20px rgba(249, 115, 22, 0.25);
+}
+
+/* Responsive */
+@media (max-width: 900px) {
+  #app-container {
+    padding: 32px 24px;
+  }
+
+  .form-row label {
+    flex: 1 1 100%;
+  }
+
+  .form-row input,
+  .category-add-row input {
+    flex: 1 1 100%;
+  }
+
+  .category-grid {
+    flex-direction: column;
+  }
+}
+
+@media (max-width: 600px) {
+  body {
+    padding: 24px 16px;
+  }
+
+  #app-container {
+    padding: 28px 20px;
+  }
+
+  section {
+    padding: 22px 20px;
+  }
+}
+
+.subtask-page section {
+  margin-bottom: 0;
+}
+
+.back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 12px;
+  color: #2563eb;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.back-link:hover {
+  text-decoration: underline;
 }

--- a/subtask.html
+++ b/subtask.html
@@ -7,16 +7,17 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <h1 id="subtask-header"></h1>
-
-  <div class="form-row">
-    <input type="text" id="new-subtask-text" placeholder="New subtask text" style="margin-right: 10px;"/>
-    <button id="add-subtask-btn">Add Subtask</button>
+  <div id="app-container" class="subtask-page">
+    <section class="subtask-section">
+      <h1 id="subtask-header"></h1>
+      <div class="form-row stack-on-small subtask-form">
+        <input type="text" id="new-subtask-text" placeholder="New subtask text" aria-label="New subtask text" />
+        <button id="add-subtask-btn" class="secondary-button">Add Subtask</button>
+      </div>
+      <ul id="subtask-list" class="category-task-list"></ul>
+      <a href="index.html" class="back-link">← Back to main list</a>
+    </section>
   </div>
-
-  <ul id="subtask-list"></ul>
-
-  <a href="index.html">Back to main list</a>
 
   <script src="subtask.js"></script>
 </body>

--- a/subtask.js
+++ b/subtask.js
@@ -16,11 +16,21 @@ function findTask(taskId, tasks) {
 
 // Finds a task by its ID across all data
 function findTaskById(data, taskId) {
-    let task = findTask(taskId, data.standard);
-    if (task) return task;
+    if (Array.isArray(data.standard)) {
+        const looksLikeCategories = data.standard.some(item => item && item.tasks !== undefined);
+        if (looksLikeCategories) {
+            for (const category of data.standard) {
+                const found = findTask(taskId, Array.isArray(category.tasks) ? category.tasks : []);
+                if (found) return found;
+            }
+        } else {
+            const found = findTask(taskId, data.standard);
+            if (found) return found;
+        }
+    }
     for (const group of data.groups) {
-        task = findTask(taskId, group.tasks);
-        if (task) return task;
+        const found = findTask(taskId, group.tasks);
+        if (found) return found;
     }
     return null;
 }
@@ -32,6 +42,7 @@ function renderSubtasks(parentTask, container) {
     }
     parentTask.subtasks.forEach(subtask => {
         const li = document.createElement('li');
+        li.className = 'task-item';
         const span = document.createElement('span');
         span.textContent = subtask.text;
         span.className = 'task-text';


### PR DESCRIPTION
## Summary
- organize standard tasks into named categories rendered as bordered columns with per-category task controls
- migrate stored data and subtask handling to support the new categorized task structure
- refresh layout and styling for the main dashboard and subtask editor to create balanced spacing and hierarchy

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68cde26e87a8832186177399bd50af03